### PR TITLE
会話前の設定画面のコンポーネントの表示を修正

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -552,6 +552,10 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
                       <RagToggleSwitch label="RAG機能" />
                     </div>
                   )}
+                  <div
+                      className="h-[124px] bg-white dark:bg-[#343541]"
+                      ref={messagesEndRef}
+                  />
                 </div>
               </>
             ) : (

--- a/components/Chat/RagCheckboxDialog.tsx
+++ b/components/Chat/RagCheckboxDialog.tsx
@@ -30,7 +30,7 @@ const CheckboxDialog: React.FC<Props> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
       <div className="bg-white dark:bg-[#343541] rounded-lg p-6 w-80 relative">
         <h2 className="text-lg font-bold mb-4 text-neutral-900 dark:text-white">RAGのタグを選択</h2>
         <div className="flex flex-col">

--- a/components/Chat/RagToggleSwitch.tsx
+++ b/components/Chat/RagToggleSwitch.tsx
@@ -72,10 +72,10 @@ const RagToggleSwitch: React.FC<Props> = ({ label}) => {
 
       {selectedOptions.length > 0 && isRagChecked && (
         <div
-          className="mt-4 p-4 border border-neutral-200 bg-transparent rounded-lg cursor-pointer relative dark:border-neutral-600 z-10"
+          className="mt-4 p-4 border border-neutral-200 bg-transparent rounded-lg cursor-pointer relative dark:border-neutral-600"
           onClick={handleDialogAreaClick}
         >
-          <span className="absolute top-0 left-2 transform -translate-y-1/2 bg-white px-1 text-sm text-neutral-700 dark:bg-[#343541] dark:text-neutral-400 pointer-events-none z-0">
+          <span className="absolute top-0 left-2 transform -translate-y-1/2 bg-white px-1 text-sm text-neutral-700 dark:bg-[#343541] dark:text-neutral-400 pointer-events-none">
             タグの選択
           </span>
           {selectedOptions.map((option, index) => (

--- a/components/Chat/Temperature.tsx
+++ b/components/Chat/Temperature.tsx
@@ -1,9 +1,6 @@
 import { FC, useContext, useState } from 'react';
-
 import { useTranslation } from 'next-i18next';
-
 import { DEFAULT_TEMPERATURE } from '@/utils/app/const';
-
 import HomeContext from '@/pages/api/home/home.context';
 
 interface Props {
@@ -30,7 +27,7 @@ export const TemperatureSlider: FC<Props> = ({
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="relative flex flex-col">
       <label className="mb-2 text-left text-neutral-700 dark:text-neutral-400">
         {label}
       </label>
@@ -51,17 +48,18 @@ export const TemperatureSlider: FC<Props> = ({
         value={temperature}
         onChange={handleChange}
       />
-      <ul className="w mt-2 pb-8 flex justify-between px-[24px] text-neutral-900 dark:text-neutral-100">
+      <ul className="absolute bottom-[12px] left-0 right-0 flex justify-between px-[8px] text-neutral-900 dark:text-neutral-100">
         <li className="flex justify-center">
-          <span className="absolute">{t('Precise')}</span>
+          <span>{t('Precise')}</span>
         </li>
         <li className="flex justify-center">
-          <span className="absolute">{t('Neutral')}</span>
+          <span>{t('Neutral')}</span>
         </li>
         <li className="flex justify-center">
-          <span className="absolute">{t('Creative')}</span>
+          <span>{t('Creative')}</span>
         </li>
       </ul>
+      <div className="mt-8"></div> {/* さらに下のコンポーネントとの距離を調整 */}
     </div>
   );
 };


### PR DESCRIPTION
会話前の設定画面のコンポーネントと、チャットのインプットのコンポーネントが重なっている不具合を修正。設定画面のコンポーネントの下に124pxのスペースを作ることで対応。また、TemperatureのPrecise, Neutral, Creativeの文字がスクロールすると移動する不具合を修正。