### PR TITLE
RAGのタグを選択するダイアログがチャットのコンポーネントの裏に隠れる不具合を修正

### DIFF
--- a/components/Chat/RagCheckboxDialog.tsx
+++ b/components/Chat/RagCheckboxDialog.tsx
@@ -30,7 +30,7 @@ const CheckboxDialog: React.FC<Props> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
       <div className="bg-white dark:bg-[#343541] rounded-lg p-6 w-80 relative">
         <h2 className="text-lg font-bold mb-4 text-neutral-900 dark:text-white">RAGのタグを選択</h2>
         <div className="flex flex-col">


### PR DESCRIPTION
RAGのタグを選択するダイアログがチャットのコンポーネントの裏に隠れる不具合を修正。ダイアログのコンポーネントのcssにz-10を追加を追加し、上に表示されるよう変更。