### PR TITLE
会話中のモデルの設定画面にRAGの設定を追加。表示方法の変更。

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -561,29 +561,33 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
               </>
             ) : (
               <>
-                <div className="sticky top-0 z-10 flex justify-center border border-b-neutral-300 bg-[#f8f4e6] py-2 text-sm text-neutral-500 dark:border-none dark:bg-[#444654] dark:text-neutral-200">
-                  {t('Model')}: {selectedConversation?.model.name} | {t('Temp')}
-                  : {selectedConversation?.temperature} |
-                  <button
-                    className="ml-2 cursor-pointer hover:opacity-50"
-                    onClick={handleSettings}
-                  >
-                    <IconSettings size={18} />
-                  </button>
-                  <button
-                    className="ml-2 cursor-pointer hover:opacity-50"
-                    onClick={onClearAll}
-                  >
-                    <IconClearAll size={18} />
-                  </button>
-                </div>
-                {showSettings && (
-                  <div className="flex flex-col space-y-10 md:mx-auto md:max-w-xl md:gap-6 md:py-3 md:pt-6 lg:max-w-2xl lg:px-0 xl:max-w-3xl">
-                    <div className="flex h-full flex-col space-y-4 border-b border-neutral-200 p-4 dark:border-neutral-600 md:rounded-lg md:border">
-                      <ModelSelect />
-                    </div>
+                <div className="sticky top-0 z-10">
+                  <div className="flex justify-center border border-b-neutral-300 bg-[#f8f4e6] py-2 text-sm text-neutral-500 dark:border-none dark:bg-[#444654] dark:text-neutral-200">
+                    {t('Model')}: {selectedConversation?.model.name} | {t('Temp')}
+                    : {selectedConversation?.temperature} |
+                    <button
+                      className="ml-2 cursor-pointer hover:opacity-50"
+                      onClick={handleSettings}
+                    >
+                      <IconSettings size={18} />
+                    </button>
+                    <button
+                      className="ml-2 cursor-pointer hover:opacity-50"
+                      onClick={onClearAll}
+                    >
+                      <IconClearAll size={18} />
+                    </button>
                   </div>
-                )}
+                  
+                  {showSettings && (
+                    <div className="bg-[#f8f4e6] dark:bg-[#343541] border-b border-neutral-300 dark:border-neutral-600 p-4 shadow-md">
+                      <div className="flex h-full flex-col space-y-4 m-auto md:max-w-2xl lg:max-w-2xl xl:max-w-3xl">
+                        <ModelSelect />
+                        <RagToggleSwitch label="RAG機能" />
+                      </div>
+                    </div>
+                  )}
+                </div>
 
                 {selectedConversation?.messages.map((message, index) => (
                   <MemoizedChatMessage

--- a/components/Chat/RagToggleSwitch.tsx
+++ b/components/Chat/RagToggleSwitch.tsx
@@ -62,7 +62,7 @@ const RagToggleSwitch: React.FC<Props> = ({ label}) => {
   return (
     <div className="flex flex-col mt-4">
       <div className="flex items-center mb-2">
-        <label className="mr-2 text-left text-neutral-700 dark:text-neutral-300">
+        <label className="mr-2 text-left text-neutral-700 dark:text-neutral-400">
           {label}
         </label>
         <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
@@ -83,7 +83,7 @@ const RagToggleSwitch: React.FC<Props> = ({ label}) => {
 
       {selectedOptions.length > 0 && isRagChecked && (
         <div
-          className="mt-4 p-4 border border-neutral-200 bg-transparent rounded-lg cursor-pointer relative dark:border-neutral-600"
+          className="mt-2 p-2 border border-neutral-200 bg-transparent rounded-lg cursor-pointer relative dark:border-neutral-600"
           onClick={handleDialogAreaClick}
         >
           <span className="absolute top-0 left-2 transform -translate-y-1/2 bg-white px-1 text-sm text-neutral-700 dark:bg-[#343541] dark:text-neutral-400 pointer-events-none">
@@ -92,7 +92,7 @@ const RagToggleSwitch: React.FC<Props> = ({ label}) => {
           {selectedOptions.map((option, index) => (
             <span
               key={index}
-              className="px-3 py-1 bg-blue-500 text-white rounded-full text-sm mr-1 mb-1 inline-block"
+              className="px-3 py-1 bg-blue-500 text-white rounded-full text-sm mr-1 mt-1 inline-block"
             >
               {option}
             </span>


### PR DESCRIPTION
会話中のモデルの設定画面にRAGの設定を追加。設定部分を会話にオーバーラップして表示するよう変更。
<img width="795" alt="スクリーンショット 2024-08-15 3 16 47" src="https://github.com/user-attachments/assets/aaa2182d-3fef-4d78-8d35-2cae112615bd">
